### PR TITLE
string door

### DIFF
--- a/solidity/lockcontract/contracts/LockContract.sol
+++ b/solidity/lockcontract/contracts/LockContract.sol
@@ -19,7 +19,7 @@ contract LockContract {
         uint256 validFrom;
         uint256 validUntil;
         address owner;
-        address door;
+        string door;
         uint[] bookingIndexes;
     }
 
@@ -72,7 +72,7 @@ contract LockContract {
     }
 
     function insertOffer(
-        uint priceInWei, string objectName, string objectAddress, string ownerName, string description, address door, uint256 validFrom, uint256 validUntil
+        uint priceInWei, string objectName, string objectAddress, string ownerName, string description, string door, uint256 validFrom, uint256 validUntil
         ) public {
         
         require(validFrom < validUntil);
@@ -98,7 +98,7 @@ contract LockContract {
     }
 
     function updateOffer(
-        uint offerID, uint priceInWei, string objectName, string objectAddress, string ownerName, string description, address door, uint256 validFrom, uint256 validUntil
+        uint offerID, uint priceInWei, string objectName, string objectAddress, string ownerName, string description, string door, uint256 validFrom, uint256 validUntil
         )
          public 
          offerAvailable(offerID)
@@ -153,7 +153,7 @@ contract LockContract {
 
     function getOffer(uint offerID) public view offerAvailable(offerID) 
         returns (
-            uint priceInWei, string objectName, string objectAddress, string ownerName, string description, address door, uint256 validFrom, uint256 validUntil
+            uint priceInWei, string objectName, string objectAddress, string ownerName, string description, string door, uint256 validFrom, uint256 validUntil
             ){
         Offer storage offer = offers[offerID];
         return (


### PR DESCRIPTION
## Short Description
Da Whisper nicht wie alle anderen Eth-Funktionen auf der Adresse aufbaut, sondern direkt den PubKey benötigt, wurde die Adresse zu String geändert

Neue Version Deployed at: `0xd37d417300db59391763152d372f8bb33105ccf3bceb4e433ae3701df4f55275`

Neue Contract Adresse: 
`0xB70B82DEFD345C9b87D5BDA144747e8a2c566dd4`

## Changes made by this pull request

- Tür hat nun String als "Adresse" für Whisper

## DoD

- [x] Tests
- [ ] Doku im Wiki

## Related Issues
closes #68 